### PR TITLE
Use PyPy from Fedora 36

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,16 @@ jobs:
           tags: fedora_ppc64le:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Build s390x docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile.fedora
+          platforms: linux/s390x
+          load: true
+          tags: fedora_s390x:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Generate sysconfig.json
         run: |
           python3 generate_manylinux.py

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,10 +35,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: Dockerfile.condaforge
+          file: Dockerfile.fedora
           platforms: linux/ppc64le
           load: true
-          tags: condaforge_ppc64le:latest
+          tags: fedora_ppc64le:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Generate sysconfig.json

--- a/Dockerfile.condaforge
+++ b/Dockerfile.condaforge
@@ -1,8 +1,0 @@
-FROM quay.io/condaforge/mambaforge
-
-RUN \
-  create() { mamba install --mkdir --yes --quiet --prefix "${@}" ; } && \
-  create /opt/python/pp37-pypy37_pp73 pypy3.7=7.3 && \
-  create /opt/python/pp38-pypy38_pp73 pypy3.8=7.3 && \
-  create /opt/python/pp39-pypy39_pp73 pypy3.9=7.3 && \
-  mamba clean --yes --all

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -1,0 +1,3 @@
+FROM fedora:36
+
+RUN dnf install -y pypy3.7 pypy3.8 pypy3.9

--- a/generate_manylinux.py
+++ b/generate_manylinux.py
@@ -92,15 +92,18 @@ def armv7l():
     return sysconfig
 
 
-def condaforge_ppc64le():
+def fedora_ppc64le():
+    pythons = [
+        "pypy3.7",
+        "pypy3.8",
+        "pypy3.9",
+    ]
     sysconfig = defaultdict(list)
     cwd = os.getcwd()
-    # PyPy is not available on ppc64le via manylinux; use conda-forge instead
+    # PyPy is not available on ppc64le via manylinux; use Fedora's instead
     for arch in ["ppc64le"]:
-        docker_image = f"condaforge_{arch}"
-        for ver in PY_VERS:
-            if not ver.startswith("pp"):
-                continue
+        docker_image = f"fedora_{arch}"
+        for python in pythons:
             command = [
                 "docker",
                 "run",
@@ -110,7 +113,7 @@ def condaforge_ppc64le():
                 "-w",
                 "/io",
                 docker_image,
-                f"/opt/python/{ver}/bin/python",
+               python,
                 "/io/get_interpreter_metadata.py",
             ]
             try:
@@ -127,7 +130,7 @@ def condaforge_ppc64le():
 
 def main():
     well_known = manylinux()
-    for sysconfig in (armv7l(), condaforge_ppc64le()):
+    for sysconfig in (armv7l(), fedora_ppc64le()):
         for arch, metadatas in sysconfig.items():
             well_known[arch].extend(metadatas)
     with open("sysconfig-linux.json", "w") as f:

--- a/generate_manylinux.py
+++ b/generate_manylinux.py
@@ -100,8 +100,8 @@ def fedora_ppc64le():
     ]
     sysconfig = defaultdict(list)
     cwd = os.getcwd()
-    # PyPy is not available on ppc64le via manylinux; use Fedora's instead
-    for arch in ["ppc64le"]:
+    # PyPy is not available on ppc64le & s390x via manylinux => use Fedora's
+    for arch in ["ppc64le", "s390x"]:
         docker_image = f"fedora_{arch}"
         for python in pythons:
             command = [


### PR DESCRIPTION
Follow up to gh-18 due to faulty `EXT_SUFFIX` from conda-forge PyPy 3.7 builds.
ref: https://github.com/PyO3/maturin/pull/1258#discussion_r1018592654